### PR TITLE
Add mDNS auto-discovery for Home Assistant Wyoming

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
 >
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
@@ -30,6 +32,14 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".SettingsActivity"
+            android:label="@string/action_settings"
+            android:parentActivityName=".MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
         </activity>
     </application>
     <queries>

--- a/app/src/main/java/home/wyoming_android_tts/MainActivity.kt
+++ b/app/src/main/java/home/wyoming_android_tts/MainActivity.kt
@@ -6,6 +6,8 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.widget.Button
 import android.widget.ScrollView
@@ -67,6 +69,21 @@ class MainActivity : AppCompatActivity() {
                 logTextView.append("\n$message")
                 logScrollView.post { logScrollView.fullScroll(View.FOCUS_DOWN) }
             }
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_settings -> {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/home/wyoming_android_tts/SettingsActivity.kt
+++ b/app/src/main/java/home/wyoming_android_tts/SettingsActivity.kt
@@ -1,0 +1,24 @@
+package home.wyoming_android_tts
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class SettingsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_settings) // We'll create this layout next
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.settings_container, SettingsFragment())
+                .commit()
+        }
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/app/src/main/java/home/wyoming_android_tts/SettingsFragment.kt
+++ b/app/src/main/java/home/wyoming_android_tts/SettingsFragment.kt
@@ -1,0 +1,11 @@
+package home.wyoming_android_tts
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+
+class SettingsFragment : PreferenceFragmentCompat() {
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences, rootKey)
+    }
+}

--- a/app/src/main/java/home/wyoming_android_tts/WyomingDiscoveryManager.kt
+++ b/app/src/main/java/home/wyoming_android_tts/WyomingDiscoveryManager.kt
@@ -1,0 +1,104 @@
+package home.wyoming_android_tts
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.util.Log
+
+class WyomingDiscoveryManager(private val context: Context) {
+
+    private val nsdManager: NsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
+    private var registrationListener: NsdManager.RegistrationListener? = null
+    private var currentServiceName: String? = null
+
+    companion object {
+        private const val TAG = "WyomingDiscoveryManager"
+        const val SERVICE_TYPE = "_wyoming._tcp"
+    }
+
+    fun registerService(instanceName: String, port: Int) {
+        if (registrationListener != null) {
+            Log.d(TAG, "Service already registered or registration in progress. Unregistering first.")
+            // Attempt to unregister previous service if any, to avoid conflicts
+            // This is a simple approach; a more robust solution might queue requests or manage states.
+            try {
+                nsdManager.unregisterService(registrationListener)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "No listener to unregister or already unregistered: ${e.message}")
+            }
+            registrationListener = null // Ensure we create a new one
+        }
+        currentServiceName = instanceName
+
+        initializeRegistrationListener()
+
+        val serviceInfo = NsdServiceInfo().apply {
+            // The name is subject to change based on conflicts
+            // however the NSD system will handle conflicts.
+            // The name you register is a suggested name.
+            serviceName = instanceName
+            serviceType = SERVICE_TYPE
+            setPort(port)
+            // No TXT records needed as per discussion
+        }
+
+        Log.d(TAG, "Attempting to register service: $instanceName, type: $SERVICE_TYPE, port: $port")
+        try {
+            nsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, registrationListener)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error registering service", e)
+            // Potentially clean up listener if registration call fails immediately
+            registrationListener = null
+            currentServiceName = null
+        }
+    }
+
+    private fun initializeRegistrationListener() {
+        registrationListener = object : NsdManager.RegistrationListener {
+            override fun onServiceRegistered(NsdServiceInfo: NsdServiceInfo) {
+                // Save the service name that Network Service Discovery successfuly registered.
+                // This might be different from the name originally requested if there was a conflict.
+                currentServiceName = NsdServiceInfo.serviceName
+                Log.i(TAG, "Service registered: ${NsdServiceInfo.serviceName}")
+            }
+
+            override fun onRegistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                // Registration failed! Put debugging code here to determine why.
+                Log.e(TAG, "Service registration failed. Error code: $errorCode, Service: ${serviceInfo.serviceName}")
+                // Clean up
+                this@WyomingDiscoveryManager.registrationListener = null
+                this@WyomingDiscoveryManager.currentServiceName = null
+            }
+
+            override fun onServiceUnregistered(arg0: NsdServiceInfo) {
+                // Service has been unregistered. This is invoked when unregisterService() is called.
+                Log.i(TAG, "Service unregistered: ${arg0.serviceName}")
+            }
+
+            override fun onUnregistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                // Unregistration failed. Put debugging code here to determine why.
+                Log.e(TAG, "Service unregistration failed. Error code: $errorCode, Service: ${serviceInfo.serviceName}")
+            }
+        }
+    }
+
+    fun unregisterService() {
+        Log.d(TAG, "Attempting to unregister service")
+        if (registrationListener != null) {
+            try {
+                nsdManager.unregisterService(registrationListener)
+                Log.i(TAG, "Unregister service call successful for listener: $registrationListener")
+            } catch (e: IllegalArgumentException) {
+                // This can happen if the listener was not registered or already unregistered
+                Log.w(TAG, "Error unregistering service: Listener not valid or already unregistered. ${e.message}")
+            } finally {
+                // Clean up references regardless of success or failure of the unregister call itself,
+                // as the listener instance is now considered consumed.
+                registrationListener = null
+                currentServiceName = null
+            }
+        } else {
+            Log.d(TAG, "No active registration listener to unregister.")
+        }
+    }
+}

--- a/app/src/main/java/home/wyoming_android_tts/WyomingTtsService.kt
+++ b/app/src/main/java/home/wyoming_android_tts/WyomingTtsService.kt
@@ -9,6 +9,7 @@ import android.os.IBinder
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import androidx.core.app.NotificationCompat
+import androidx.preference.PreferenceManager
 import kotlinx.coroutines.*
 import org.json.JSONArray
 import org.json.JSONException
@@ -33,11 +34,14 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
 
     companion object {
         private const val NOTIFICATION_ID = 1
-        private const val SERVER_PORT = 10300
+        // Default values, will be overridden by preferences
+        private const val DEFAULT_SERVER_PORT = 10300
+        private const val DEFAULT_SERVICE_NAME = "Wyoming Android TTS"
         private const val WYOMING_PROTOCOL_VERSION = "1.6.0"
         private const val APP_VERSION = "1.0.0"
     }
     private var serverSocket: ServerSocket? = null
+    private var currentPort: Int = DEFAULT_SERVER_PORT
     private val serviceJob = SupervisorJob()
     private val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
     private var serverListeningJob: Job? = null
@@ -45,6 +49,8 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
     private var ttsInitialized = false
     private val ttsUtteranceRequests = mutableMapOf<String, CompletableDeferred<File?>>()
     private data class WavInfo(val sampleRate: Int, val channels: Int, val bitsPerSample: Int)
+
+    private lateinit var wyomingDiscoveryManager: WyomingDiscoveryManager
 
     private fun readLineFromStream(inputStream: InputStream, clientAddress: String): String? {
         val lineBuffer = java.io.ByteArrayOutputStream()
@@ -269,6 +275,7 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
     override fun onCreate() {
         super.onCreate()
         AppLogger.log("Service creating...")
+        wyomingDiscoveryManager = WyomingDiscoveryManager(applicationContext)
         setupTextToSpeech()
     }
 
@@ -503,9 +510,11 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         AppLogger.log("Service starting...")
+        loadPreferences() // Load preferences before starting server and notification
+
         val notification: Notification = NotificationCompat.Builder(this, WyomingTtsApp.CHANNEL_ID)
             .setContentTitle(getString(R.string.notification_title))
-            .setContentText(getString(R.string.notification_message_listening, SERVER_PORT))
+            .setContentText(getString(R.string.notification_message_listening, currentPort))
             .setSmallIcon(R.mipmap.ic_launcher)
             .build()
         startForeground(NOTIFICATION_ID, notification)
@@ -513,15 +522,27 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
         return START_STICKY
     }
 
+    private fun loadPreferences() {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        currentPort = sharedPreferences.getString("service_port", DEFAULT_SERVER_PORT.toString())?.toIntOrNull() ?: DEFAULT_SERVER_PORT
+        // Service name will be read directly in startServer when registering
+        AppLogger.log("Loaded preferences: Port=$currentPort")
+    }
+
     private fun startServer() {
         if (serverListeningJob?.isActive == true) {
-            AppLogger.log("Server already running on port $SERVER_PORT")
+            AppLogger.log("Server already running on port $currentPort")
             return
         }
         serverListeningJob = serviceScope.launch {
             try {
-                serverSocket = ServerSocket(SERVER_PORT)
-                AppLogger.log("Server started, listening on port $SERVER_PORT")
+                serverSocket = ServerSocket(currentPort)
+                AppLogger.log("Server started, listening on port $currentPort")
+
+                val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+                val serviceName = sharedPreferences.getString("service_name", DEFAULT_SERVICE_NAME) ?: DEFAULT_SERVICE_NAME
+                wyomingDiscoveryManager.registerService(serviceName, currentPort)
+
                 while (isActive) {
                     try {
                         val clientSocket = serverSocket!!.accept()
@@ -544,11 +565,15 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
 
     private fun stopServer() {
         AppLogger.log("Stopping server...")
+        wyomingDiscoveryManager.unregisterService()
         serverListeningJob?.cancel()
-        serviceJob.cancel()
+        // serviceJob.cancel() // Cancelling serviceJob here might be too early if unregisterService relies on it or if other coroutines use it.
+                           // NsdManager operations are asynchronous. Consider if serviceJob needs to be active for callbacks.
+                           // For now, assume NsdManager handles its own threading for unregistration.
         try {
             serverSocket?.close()
             serverSocket = null
+            AppLogger.log("Server socket closed.")
         } catch (e: IOException) {
             AppLogger.log("Error closing server socket: ${e.message}", AppLogger.LogLevel.ERROR)
         }
@@ -557,7 +582,7 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
     override fun onDestroy() {
         super.onDestroy()
         AppLogger.log("Service destroying...")
-        stopServer()
+        stopServer() // This now calls unregisterService()
         if (tts != null) {
             AppLogger.log("[TTS] Shutting down TextToSpeech engine.", AppLogger.LogLevel.INFO)
             tts?.stop()
@@ -565,6 +590,7 @@ class WyomingTtsService : Service(), TextToSpeech.OnInitListener {
             tts = null
             ttsInitialized = false
         }
+        serviceJob.cancel() // Cancel the main service job as one of the last steps
         AppLogger.log("Service destroyed.")
     }
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/settings_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SettingsActivity" />

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:title="@string/action_settings"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,12 @@
     <string name="notification_title">Wyoming TTS Service</string>
     <string name="notification_message">Service is running to provide TTS.</string>
     <string name="notification_message_listening">Listening on port %1$d for TTS requests.</string>
+
+    <!-- Preference Titles and Summaries -->
+    <string name="pref_category_network_title">Network Settings</string>
+    <string name="pref_service_name_title">Service Name</string>
+    <string name="pref_service_name_summary">The name your TTS service will be advertised as on the network (mDNS).</string>
+    <string name="pref_service_port_title">Service Port</string>
+    <string name="pref_service_port_summary">The network port the TTS service will listen on.</string>
+    <string name="action_settings">Settings</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        app:title="@string/pref_category_network_title">
+
+        <EditTextPreference
+            app:key="service_name"
+            app:title="@string/pref_service_name_title"
+            app:summary="@string/pref_service_name_summary"
+            app:defaultValue="Wyoming Android TTS"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
+            app:key="service_port"
+            app:title="@string/pref_service_port_title"
+            app:summary="@string/pref_service_port_summary"
+            app:defaultValue="10300"
+            app:useSimpleSummaryProvider="true"
+            app:inputType="number" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
Implements mDNS (Zeroconf) service discovery using Android's NsdManager to allow Home Assistant's Wyoming integration to automatically discover the TTS service.

Key features:
- Registers `_wyoming._tcp` service type.
- Service instance name is configurable (default: "Wyoming Android TTS").
- Service port is configurable (default: 10300).
- Adds a settings screen for configuring the service name and port.
- Integrates discovery lifecycle with the WyomingTtsService lifecycle.