### PR TITLE
Fix: Adjust layout for status bar

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
     <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
Added android:fitsSystemWindows="true" to the root LinearLayout in activity_main.xml to prevent the app layout from overlapping with the Android status bar.