### PR TITLE
Enable ActionBar to make Settings accessible

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/settings_container"
     android:layout_width="match_parent"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-    <!-- <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar"> -->
+    <!-- <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar"> -->
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
     <!-- <style name="AppTheme" parent="android:Theme.DeviceDefault.Light"> -->
     </style>
     <style name="Theme.WyomingAndroidTTS" parent="AppTheme">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,19 +3,19 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
-        title="@string/pref_category_network_title">
+        android:title="@string/pref_category_network_title">
 
         <EditTextPreference
-            key="service_name"
-            title="@string/pref_service_name_title"
-            summary="@string/pref_service_name_summary"
-            defaultValue="Wyoming Android TTS" />
+            android:key="service_name"
+            android:title="@string/pref_service_name_title"
+            android:summary="@string/pref_service_name_summary"
+            android:defaultValue="Wyoming Android TTS" />
 
         <EditTextPreference
-            key="service_port"
-            title="@string/pref_service_port_title"
-            summary="@string/pref_service_port_summary"
-            defaultValue="10300"
+            android:key="service_port"
+            android:title="@string/pref_service_port_title"
+            android:summary="@string/pref_service_port_summary"
+            android:defaultValue="10300"
             android:inputType="number" />
 
     </PreferenceCategory>


### PR DESCRIPTION
The application was using a NoActionBar theme, which prevented the display of the overflow menu and therefore access to the SettingsActivity.

This commit changes the AppTheme to Theme.MaterialComponents.DayNight.DarkActionBar, which includes an ActionBar by default. This allows MainActivity to display the options menu, making the Settings option accessible via the overflow menu.